### PR TITLE
fix(javaserver): the package messup fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode

--- a/employee/pom.xml
+++ b/employee/pom.xml
@@ -15,6 +15,7 @@
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>19</java.version>
+		<start-class>com.example.employee.EmployeeApplication</start-class>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/employee/src/main/java/com/example/employee/Employee.java
+++ b/employee/src/main/java/com/example/employee/Employee.java
@@ -1,4 +1,4 @@
-package Tests.employee;
+package com.example.employee;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.annotation.Id;
 import org.bson.types.ObjectId;

--- a/employee/src/main/java/com/example/employee/EmployeeApplication.java
+++ b/employee/src/main/java/com/example/employee/EmployeeApplication.java
@@ -1,11 +1,11 @@
-package Tests.employee;
+package com.example.employee;
 
-import java.util.Arrays;
 
-import org.springframework.boot.CommandLineRunner;
+
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.ApplicationContext;
+
 
 
 @SpringBootApplication

--- a/employee/src/main/java/com/example/employee/EmployeeRepository.java
+++ b/employee/src/main/java/com/example/employee/EmployeeRepository.java
@@ -1,9 +1,9 @@
-package Tests.employee;
-// import springboot.api.employee.*; 
+package com.example.employee;
+
 import org.bson.types.ObjectId;
-// import com.example
+
 import org.springframework.data.mongodb.repository.MongoRepository;
-import java.util.*;
+
 public interface EmployeeRepository extends MongoRepository<Employee2, ObjectId> {
     Employee findById(int id);
     void deleteById(int id);

--- a/employee/src/main/java/com/example/employee/HelloController.java
+++ b/employee/src/main/java/com/example/employee/HelloController.java
@@ -1,20 +1,20 @@
-package Tests.employee;
+package com.example.employee;
 
 import java.util.*;
 
-import javax.lang.model.type.ErrorType;
-import org.springframework.dao.EmptyResultDataAccessException;
+
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.PathVariable;
-import netscape.javascript.JSObject;
+
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestMapping;
+
 import org.springframework.web.bind.annotation.CrossOrigin;
-import org.json.JSONObject;
+
 
 // import com.example.accessingdatamongodb.Employee;
 import com.google.gson.Gson;

--- a/employee/src/main/java/com/example/employee/MySQLfunc.java
+++ b/employee/src/main/java/com/example/employee/MySQLfunc.java
@@ -1,4 +1,4 @@
-package Tests.employee;
+package com.example.employee;
 import java.util.ArrayList;
 
 import java.sql.*;


### PR DESCRIPTION
Error arrising due to change in package name fixed, now works with just clone, no requirement for updating the pom file. There was a
<start-class>com.example.employee.EmployeeApplication</start-class> required in the pom properties div. This was a fix for the no main class found in the following candidates error.